### PR TITLE
Removed undefined when calling callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function play (input, options, callback) {
   });
 
   function onPlayerReady (event) {
-    callback && callback(undefined, event.target);
+    callback && callback(event.target);
   }
 
   function onPlayerStateChange (event) {


### PR DESCRIPTION
I'm not sure why the first parameter for callback is undefined.

This pull request simply removes the undefined value being passed to the callback.
