### PR TITLE
Add support all YouTube JS API player vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,25 +74,6 @@ function pickID (input) {
   if (match) return match[0];
 }
 
-/**
- * Check that a value is within the acceptable values for the given parameter.
- * @type {string} param - The parameter name.
- * @type {mixed}  val   - The value the user has provided.
- * @return {mixed} The passed value if it's permitted or NULL otherwise.
- */
-function getEnumeratedValue(param, val) {
-  var enumeratedValues = {
-    color: ['red', 'white'],
-    listType: ['search', 'user_uploads', 'playlist'],
-  };
-
-  if (!enumeratedValues.hasOwnProperty(param)) {
-    return val;
-  }
-
-  return -1 !== enumeratedValues[param].indexOf(val) ? val : null;
-}
-
 function defaultElementId () {
   var id = 'youtube-video';
   var defaultEl = document.getElementById(id);

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var extend = require('extend');
 var findall = require("findall");
 var newElement = require('new-element');
 var sdk = require('require-sdk')('https://www.youtube.com/iframe_api', 'YT');
@@ -22,23 +23,21 @@ function play (input, options, callback) {
   var elementId = options.selector ? options.elementId : defaultElementId();
 
   sdk(function (error, youtube) {
+    var playerVars = {};
+
     api = youtube;
+
+    // Assemble the playerVars object using the passed options (except top-level items).
+    extend(playerVars, options);
+    delete playerVars.width;
+    delete playerVars.height;
 
     player = new api.Player(
       elementId,
       {
         height: options.height,
         width: options.width,
-        playerVars: {
-          autoplay: options.autoplay ? 1 : 0,
-          cc_load_policy: options.cc_load_policy ? 1 : 0,
-          color: getEnumeratedValue('color', options.color),
-          controls: options.controls ? 1 : 0,
-          disablekb: options.disablekb ? 1 : 0,
-          list: options.list || null,
-          listType: getEnumeratedValue('listType', options.listType),
-          loop: options.loop ? 1 : 0,
-        },
+        playerVars: playerVars,
         videoId: pickID(input),
         events: {
           'onReady': onPlayerReady,

--- a/index.js
+++ b/index.js
@@ -28,9 +28,10 @@ function play (input, options, callback) {
     api = youtube;
 
     // Assemble the playerVars object using the passed options (except top-level items).
-    extend(playerVars, options);
+    extend(playerVars, options, options.playerVars);
     delete playerVars.width;
     delete playerVars.height;
+    delete playerVars.playerVars;
 
     // Automatically cast any boolean values as integers.
     for (var i in playerVars) {

--- a/index.js
+++ b/index.js
@@ -32,6 +32,13 @@ function play (input, options, callback) {
     delete playerVars.width;
     delete playerVars.height;
 
+    // Automatically cast any boolean values as integers.
+    for (var i in playerVars) {
+      if ('boolean' === typeof playerVars[i]) {
+        playerVars[i] = playerVars[i] ? 1 : 0;
+      }
+    }
+
     player = new api.Player(
       elementId,
       {

--- a/index.js
+++ b/index.js
@@ -31,8 +31,13 @@ function play (input, options, callback) {
         width: options.width,
         playerVars: {
           autoplay: options.autoplay ? 1 : 0,
+          cc_load_policy: options.cc_load_policy ? 1 : 0,
+          color: getEnumeratedValue('color', options.color),
           controls: options.controls ? 1 : 0,
-          loop: options.loop ? 1 : 0
+          disablekb: options.disablekb ? 1 : 0,
+          list: options.list || null,
+          listType: getEnumeratedValue('listType', options.listType),
+          loop: options.loop ? 1 : 0,
         },
         videoId: pickID(input),
         events: {
@@ -68,6 +73,25 @@ function pickID (input) {
   var match = findall(input, /(?:\?|&)v=([^&]+)/);
 
   if (match) return match[0];
+}
+
+/**
+ * Check that a value is within the acceptable values for the given parameter.
+ * @type {string} param - The parameter name.
+ * @type {mixed}  val   - The value the user has provided.
+ * @return {mixed} The passed value if it's permitted or NULL otherwise.
+ */
+function getEnumeratedValue(param, val) {
+  var enumeratedValues = {
+    color: ['red', 'white'],
+    listType: ['search', 'user_uploads', 'playlist'],
+  };
+
+  if (!enumeratedValues.hasOwnProperty(param)) {
+    return val;
+  }
+
+  return -1 !== enumeratedValues[param].indexOf(val) ? val : null;
 }
 
 function defaultElementId () {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "test": "browserify test.js | tape-run --browser=firefox"
   },
   "dependencies": {
-    "require-sdk": "0.0.0",
+    "extend": "^3.0.0",
     "findall": "0.0.4",
-    "new-element": "0.0.1"
+    "new-element": "0.0.1",
+    "require-sdk": "0.0.0"
   },
   "devDependencies": {
     "browserify": "13.0.0",

--- a/test.js
+++ b/test.js
@@ -42,5 +42,22 @@ test('plays a youtube video', function(t){
     t.ok(paused)
     t.end();
   }
+});
 
+test('supports all playerVars parameters', function(t){
+  var options = {
+    autoplay: true,
+    controls: false,
+    loop: true,
+  }
+  t.plan(options.length);
+
+  video('tUsYb6Jkvt8', options, function (error, playback) {
+    var src = document.getElementById('youtube-video').getAttribute('src');
+
+    t.notEqual(-1, src.indexOf('autoplay=1'), 'autoplay parameter is supported');
+    t.notEqual(-1, src.indexOf('controls=0'), 'controls parameter is supported');
+    t.notEqual(-1, src.indexOf('loop=1'), 'loop parameter is supported');
+    t.end()
+  });
 });

--- a/test.js
+++ b/test.js
@@ -46,12 +46,12 @@ test('plays a youtube video', function(t){
 
 test('supports all playerVars parameters', function(t){
   var options = {
-    autoplay: true,
-    cc_load_policy: true,
+    autoplay: 1,
+    cc_load_policy: 1,
     color: 'white',
-    controls: false,
-    disablekb: true,
-    loop: true,
+    controls: 0,
+    disablekb: 1,
+    loop: 1,
   }
   t.plan(options.length);
 

--- a/test.js
+++ b/test.js
@@ -102,3 +102,37 @@ test('supports search list type', function(t) {
     t.end()
   });
 });
+
+test('supports playlist list type', function(t) {
+  var options = {
+    list: 'PLwlF1uffYtXo08VWYny-lVJ89niu4KIdm',
+    listType: 'playlist',
+  }
+  t.plan(3);
+
+  video(null, options, function (error, playback) {
+    var src = document.getElementById('youtube-video').getAttribute('src');
+
+    t.notEqual(-1, src.indexOf('list=PLwlF1uffYtXo08VWYny-lVJ89niu4KIdm'), 'playlist IDs are supported');
+    t.notEqual(-1, src.indexOf('listType=playlist'), 'playlists are supported');
+    t.ok(playback.getPlaylist(), 'YouTube has playlists of cute cat videos');
+    t.end()
+  });
+});
+
+test('supports user_uploads list type', function(t) {
+  var options = {
+    list: 'UC9egiwuJsQZ0Cy2to5fvSIQ',
+    listType: 'user_uploads',
+  }
+  t.plan(3);
+
+  video(null, options, function (error, playback) {
+    var src = document.getElementById('youtube-video').getAttribute('src');
+
+    t.notEqual(-1, src.indexOf('list=UC9egiwuJsQZ0Cy2to5fvSIQ'), 'user upload list IDs are supported');
+    t.notEqual(-1, src.indexOf('listType=user_uploads'), 'user upload playlists are supported');
+    t.ok(playback.getPlaylist(), 'YouTube has a whole channel of cat videos');
+    t.end()
+  });
+});

--- a/test.js
+++ b/test.js
@@ -136,3 +136,21 @@ test('supports user_uploads list type', function(t) {
     t.end()
   });
 });
+
+test('casts boolean playerVars as integers', function(t) {
+  var options = {
+    autoplay: true,
+    controls: false,
+    loop: true,
+  }
+  t.plan(options.length);
+
+  video('tUsYb6Jkvt8', options, function (error, playback) {
+    var src = document.getElementById('youtube-video').getAttribute('src');
+
+    t.notEqual(-1, src.indexOf('autoplay=1'), 'autoplay parameter is being cast as an integer');
+    t.notEqual(-1, src.indexOf('controls=0'), 'controls parameter is being cast as an integer');
+    t.notEqual(-1, src.indexOf('loop=1'), 'loop parameter is being cast as an integer');
+    t.end()
+  });
+});

--- a/test.js
+++ b/test.js
@@ -143,7 +143,7 @@ test('casts boolean playerVars as integers', function(t) {
     controls: false,
     loop: true,
   }
-  t.plan(options.length);
+  t.plan(3);
 
   video('tUsYb6Jkvt8', options, function (error, playback) {
     var src = document.getElementById('youtube-video').getAttribute('src');
@@ -151,6 +151,25 @@ test('casts boolean playerVars as integers', function(t) {
     t.notEqual(-1, src.indexOf('autoplay=1'), 'autoplay parameter is being cast as an integer');
     t.notEqual(-1, src.indexOf('controls=0'), 'controls parameter is being cast as an integer');
     t.notEqual(-1, src.indexOf('loop=1'), 'loop parameter is being cast as an integer');
+    t.end()
+  });
+});
+
+test('accepts and merges a playerVars option', function(t) {
+  var options = {
+    autoplay: 1,
+    playerVars: {
+      autoplay: 0,
+      controls: 0,
+    },
+  }
+  t.plan(2);
+
+  video('tUsYb6Jkvt8', options, function (error, playback) {
+    var src = document.getElementById('youtube-video').getAttribute('src');
+
+    t.notEqual(-1, src.indexOf('autoplay=0'), 'autoplay is being overridden by playerVars.autoplay');
+    t.notEqual(-1, src.indexOf('controls=0'), 'controls parameter is being recognized');
     t.end()
   });
 });

--- a/test.js
+++ b/test.js
@@ -47,7 +47,10 @@ test('plays a youtube video', function(t){
 test('supports all playerVars parameters', function(t){
   var options = {
     autoplay: true,
+    cc_load_policy: true,
+    color: 'white',
     controls: false,
+    disablekb: true,
     loop: true,
   }
   t.plan(options.length);
@@ -56,8 +59,28 @@ test('supports all playerVars parameters', function(t){
     var src = document.getElementById('youtube-video').getAttribute('src');
 
     t.notEqual(-1, src.indexOf('autoplay=1'), 'autoplay parameter is supported');
+    t.notEqual(-1, src.indexOf('cc_load_policy=1'), 'cc_load_policy parameter is supported');
+    t.notEqual(-1, src.indexOf('color=white'), 'color parameter is supported');
     t.notEqual(-1, src.indexOf('controls=0'), 'controls parameter is supported');
+    t.notEqual(-1, src.indexOf('disablekb=1'), 'controls parameter is supported');
     t.notEqual(-1, src.indexOf('loop=1'), 'loop parameter is supported');
+    t.end()
+  });
+});
+
+test('supports search list type', function(t){
+  var options = {
+    list: 'cats',
+    listType: 'search',
+  }
+  t.plan(3);
+
+  video(null, options, function (error, playback) {
+    var src = document.getElementById('youtube-video').getAttribute('src');
+
+    t.notEqual(-1, src.indexOf('list=cats'), 'search terms are supported');
+    t.notEqual(-1, src.indexOf('listType=search'), 'search playlists are supported');
+    t.ok(playback.getPlaylist(), 'YouTube has cat videos');
     t.end()
   });
 });

--- a/test.js
+++ b/test.js
@@ -44,14 +44,23 @@ test('plays a youtube video', function(t){
   }
 });
 
-test('supports all playerVars parameters', function(t){
+test('supports all playerVars parameters', function(t) {
   var options = {
     autoplay: 1,
     cc_load_policy: 1,
     color: 'white',
     controls: 0,
     disablekb: 1,
+    end: 1,
+    fs: 1,
+    hl: 'en',
+    iv_load_policy: 1,
     loop: 1,
+    modestbranding: 1,
+    playsinline: 1,
+    rel: 0,
+    showinfo: 0,
+    start: 5
   }
   t.plan(options.length);
 
@@ -62,13 +71,22 @@ test('supports all playerVars parameters', function(t){
     t.notEqual(-1, src.indexOf('cc_load_policy=1'), 'cc_load_policy parameter is supported');
     t.notEqual(-1, src.indexOf('color=white'), 'color parameter is supported');
     t.notEqual(-1, src.indexOf('controls=0'), 'controls parameter is supported');
-    t.notEqual(-1, src.indexOf('disablekb=1'), 'controls parameter is supported');
+    t.notEqual(-1, src.indexOf('disablekb=1'), 'disablekb parameter is supported');
+    t.notEqual(-1, src.indexOf('end=1'), 'end parameter is supported');
+    t.notEqual(-1, src.indexOf('fs=1'), 'fs parameter is supported');
+    t.notEqual(-1, src.indexOf('hl=en'), 'hl parameter is supported');
+    t.notEqual(-1, src.indexOf('iv_load_policy=1'), 'iv_load_policy parameter is supported');
     t.notEqual(-1, src.indexOf('loop=1'), 'loop parameter is supported');
+    t.notEqual(-1, src.indexOf('modestbranding=1'), 'modestbranding parameter is supported');
+    t.notEqual(-1, src.indexOf('playsinline=1'), 'playsinline parameter is supported');
+    t.notEqual(-1, src.indexOf('rel=0'), 'rel parameter is supported');
+    t.notEqual(-1, src.indexOf('showinfo=0'), 'showinfo parameter is supported');
+    t.notEqual(-1, src.indexOf('start=5'), 'start parameter is supported');
     t.end()
   });
 });
 
-test('supports search list type', function(t){
+test('supports search list type', function(t) {
   var options = {
     list: 'cats',
     listType: 'search',


### PR DESCRIPTION
This PR adds support for [all current (and future, assuming the API doesn't drastically change) playerVars](https://developers.google.com/youtube/player_parameters#Parameters) while setting up a new YouTube video (fixing #4 in the process).

When creating a new YouTube video instance, the arguments (except `height` and `width`) are passed through [`extend()`](https://www.npmjs.com/package/extend), enabling developers to access previously unavailable variables, including "modestbranding", "rel", and "showinfo".