### PR TITLE
Respect the `elementId` parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function play (input, options, callback) {
     options = {};
   }
 
-  var elementId = options.selector ? options.elementId : defaultElementId();
+  var elementId = options.elementId || defaultElementId();
 
   sdk(function (error, youtube) {
     api = youtube;

--- a/test.js
+++ b/test.js
@@ -44,3 +44,16 @@ test('plays a youtube video', function(t){
   }
 
 });
+
+test('respects the elementId argument', function(t) {
+  var player = document.createElement('div');
+  player.id = 'test-player';
+  document.body.appendChild(player);
+
+  t.plan(1);
+
+  video('tUsYb6Jkvt8', {elementId: 'test-player'}, function (error, playback) {
+    t.equal('test-player', playback.getIframe().id, 'elementId is being set');
+    t.end();
+  });
+});


### PR DESCRIPTION
As noted in #2, the `elementId` parameter was not being respected unless paired with the [undocumented] `selector` option. This PR fixes the discrepancy, ensuring that an `elementId` parameter is enough to change the video's parent element.