### PR TITLE
Add support for playlist URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,12 +74,23 @@ function play (input, options, callback) {
 
 }
 
+/**
+ * Parse the video ID out of a string.
+ *
+ * @param {string} input - The input string, which could be a URL or a video ID.
+ * @returns {string|null} Either the parsed video ID or NULL.
+ */
 function pickID (input) {
-  if (!/\./.test(input)) return input;
+  var videoId;
 
-  var match = findall(input, /(?:\?|&)v=([^&]+)/);
+  // Return early if there's no ".", as it's clearly not a URL.
+  if (!/\./.test(input)) {
+    return input;
+  }
 
-  if (match) return match[0];
+  videoId = /(?:\?|&)v=([^&]+)/.exec(input);
+
+  return videoId ? videoId[1] : null;
 }
 
 function defaultElementId () {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ function play (input, options, callback) {
   var elementId = options.elementId || defaultElementId();
 
   sdk(function (error, youtube) {
-    var playerVars = {};
+    var videoId = pickID(input),
+      playerVars = {},
+      playlist;
 
     api = youtube;
 
@@ -32,6 +34,16 @@ function play (input, options, callback) {
     delete playerVars.width;
     delete playerVars.height;
     delete playerVars.playerVars;
+
+    // If we don't have a video ID, check to see if `input` is a playlist.
+    if (!videoId) {
+      playlist = /(?:\?|&)list=([^&]+)/.exec(input);
+
+      if (playlist) {
+        playerVars.listType = playerVars.listType || 'playlist';
+        playerVars.list = playlist[1];
+      }
+    }
 
     // Automatically cast any boolean values as integers.
     for (var i in playerVars) {
@@ -46,7 +58,7 @@ function play (input, options, callback) {
         height: options.height,
         width: options.width,
         playerVars: playerVars,
-        videoId: pickID(input),
+        videoId: videoId,
         events: {
           'onReady': onPlayerReady,
           'onStateChange': onPlayerStateChange

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "extend": "^3.0.0",
-    "findall": "azer/findall",
     "new-element": "azer/new-element",
     "require-sdk": "azer/require-sdk"
   },

--- a/test.js
+++ b/test.js
@@ -11,6 +11,16 @@ test('plays the video at given url', function(t){
   });
 });
 
+test('plays the playlist at given url', function(t){
+  var url = 'https://www.youtube.com/playlist?list=PLwlF1uffYtXo08VWYny-lVJ89niu4KIdm';
+  t.plan(1)
+
+  video(url, function (error, playback) {
+    t.equal(playback.getPlaylistId(), 'PLwlF1uffYtXo08VWYny-lVJ89niu4KIdm');
+    t.end()
+  });
+});
+
 test('plays a youtube video', function(t){
   var options = {
     width: 300,


### PR DESCRIPTION
This PR adds support for playlist URLs (example: `https://www.youtube.com/playlist?list=PLwlF1uffYtXo08VWYny-lVJ89niu4KIdm`) when constructing a new YouTube player.

There's also a small performance gain by dropping the `azer/findall` dependency, since we only need a single match, not an array of them for video/playlist IDs.